### PR TITLE
Add database resources configuration files for PostgreSQL

### DIFF
--- a/backend/deploy/db/deployment.yaml
+++ b/backend/deploy/db/deployment.yaml
@@ -1,0 +1,42 @@
+# deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: users-permissions-db
+spec:
+  selector:
+    matchLabels:
+      app: users-permissions-db
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: users-permissions-db
+    spec:
+      containers:
+        - name: users-permissions-db
+          image: postgres:17
+          ports:
+            - containerPort: 5432
+              name: "postgres"
+          volumeMounts:
+            - mountPath: "/var/lib/postgresql/data"
+              name: users-permissions-postgres-data-storage
+          env:
+            - name: POSTGRES_DB
+              value: postgres
+            - name: POSTGRES_USER
+              value: postgres
+            - name: POSTGRES_PASSWORD
+              valueFrom: 
+                secretKeyRef:
+                  name: db-password
+                  key: password
+          resources:
+            limits:
+              memory: 4Gi
+              cpu: "2"
+      volumes:
+        - name: users-permissions-postgres-data-storage
+          persistentVolumeClaim:
+            claimName: users-permissions-postgres-data-persistent-volume-claim  

--- a/backend/deploy/db/persistent-volume-claim.yaml
+++ b/backend/deploy/db/persistent-volume-claim.yaml
@@ -1,0 +1,13 @@
+# persistent-volume-claim.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: users-permissions-postgres-data-persistent-volume-claim
+spec:
+  volumeName: users-permissions-postgres-data-persistent-volume
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/backend/deploy/db/persistent-volume.yaml
+++ b/backend/deploy/db/persistent-volume.yaml
@@ -1,0 +1,18 @@
+# persistent-volume.yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: users-permissions-postgres-data-persistent-volume
+  labels:
+    type: local
+spec:
+  claimRef:
+    namespace: default
+    name: users-permissions-postgres-data-persistent-volume-claim
+  storageClassName: manual
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/mnt/data"

--- a/backend/deploy/db/secret.yaml
+++ b/backend/deploy/db/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-password
+type: Opaque
+data:
+  password: cG9zdGdyZXMK

--- a/backend/deploy/db/service.yaml
+++ b/backend/deploy/db/service.yaml
@@ -1,0 +1,15 @@
+# service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: users-permissions-db-service
+spec:
+  type: NodePort
+  selector:
+    app: users-permissions-db
+  ports:
+    - name: "postgres"
+      protocol: TCP
+      port: 5432
+      targetPort: 5432
+      nodePort: 30432


### PR DESCRIPTION
Added resources necessary for postgreSQL db deployment. The database can be easily changed if we choose so. This is very basic config, but should work. It persists the data of the database on the node filesystem, even when pod is destroyed 🔢 💯 .  Not sure if I handled the secret configuration correctly would appreciate feedback.